### PR TITLE
nixus.groups: added ability to put nodes into groups

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -36,6 +36,7 @@ let
       modules/public-ip.nix
       modules/dns.nix
       modules/vpn
+      modules/groups.nix
       conf
       # Not naming it pkgs to avoid confusion and trouble for overriding scopes
       {

--- a/modules/groups.nix
+++ b/modules/groups.nix
@@ -1,0 +1,41 @@
+{ config, lib, nixus, ... }:
+
+let
+  inherit (lib) types;
+
+  # we need to reference the global configuration
+  # in our submodule.
+  gconfig = config;
+
+  groupOpts = { config, ... }: {
+    options = {
+      deployScript = lib.mkOption {
+        type = types.package;
+        readOnly = true;
+      };
+
+      members = lib.mkOption {
+        type = types.listOf types.str;
+        default = [];
+      };
+    };
+
+    config.deployScript = let
+      mkDeployScript = members: nixus.pkgs.writeScript "deploy" ''
+        #!${nixus.pkgs.runtimeShell}
+        ${lib.concatMapStrings (nodeName: lib.optionalString gconfig.nodes.${nodeName}.enabled ''
+
+          ${gconfig.nodes.${nodeName}.deployScript} &
+        '') config.members}
+        wait
+      '';
+    in mkDeployScript config.members;
+  };
+in {
+  options = {
+    groups = lib.mkOption {
+      type = types.attrsOf (types.submodule groupOpts);
+      default = {};
+    };
+  };
+}

--- a/modules/groups.nix
+++ b/modules/groups.nix
@@ -3,8 +3,7 @@
 let
   inherit (lib) types;
 
-  # we need to reference the global configuration
-  # in our submodule.
+  # we need to reference the global configuration in our submodule.
   gconfig = config;
 
   groupOpts = { config, ... }: {
@@ -21,8 +20,7 @@ let
     };
 
     config.deployScript = let
-      mkDeployScript = members: nixus.pkgs.writeScript "deploy" ''
-        #!${nixus.pkgs.runtimeShell}
+      mkDeployScript = members: nixus.pkgs.writeShellScript "deploy" ''
         ${lib.concatMapStrings (nodeName: lib.optionalString gconfig.nodes.${nodeName}.enabled ''
 
           ${gconfig.nodes.${nodeName}.deployScript} &
@@ -36,6 +34,22 @@ in {
     groups = lib.mkOption {
       type = types.attrsOf (types.submodule groupOpts);
       default = {};
+      description = ''
+        Allows creating groups of nodes for deploying them together, instead of deploying all nodes.
+        Building the script for deploying can be done like `nix-build -A config.groups.home.deployScript`
+     '';
+      example = {
+        servers = [
+          "vps-web"
+          "vps-web2"
+          "vps-db"
+        ];
+        home = [
+          "eos"
+          "server1"
+          "router"
+        ];
+      };
     };
   };
 }


### PR DESCRIPTION
This allows for declaring groups of nodes, ie. all home computers, all servers, VPS, etc. which allows to deploy one group at a time.
Example configuration could be:

```
{
  groups = {
    home.members = [
        "router"
        "server1"
        "eos"
    ];
    vps.members = [
        "vps1"
        "vps2"
        "vps3"
    ];
  };
}
```

And then building the script using `nix-build -A config.groups.vps.deployScript deploy/`.

I am unsure of having defaults that should be set for each group, would be a nice addition (also not sure how to implement it best).

# TODO

- [x] Need to add descriptions