### PR TITLE
adds support for activating system on next boot instead

### DIFF
--- a/modules/deploy.nix
+++ b/modules/deploy.nix
@@ -41,6 +41,17 @@ let
         '';
       };
 
+      switchAction = lib.mkOption {
+        type = lib.types.enum [ "switch" "boot" ];
+        default = "switch";
+        description = ''
+          The switch action to use when deploying. "switch" activates the new
+          system immediately with confirmation and automatic rollback support.
+          "boot" only sets the system as the default for the next reboot,
+          without activating it immediately.
+        '';
+      };
+
       ignoreFailingSystemdUnits = lib.mkOption {
         type = types.bool;
         default = false;
@@ -336,6 +347,15 @@ in {
 
           echo "Deploying.." >&2
 
+          ${if nodeConfig.switchAction == "boot" then ''
+          echo "Setting next boot system..." >&2
+          id="N/A"
+          if ssh "$HOST" exec "${nodeConfig.closurePaths.switch}/bin/switch" boot "${nodeConfig.closurePaths.system}"; then
+            status="success"
+          else
+            status="failure"
+          fi
+          '' else ''
           echo "Triggering system switcher..." >&2
           id=$(ssh "$HOST" exec "${nodeConfig.closurePaths.switch}/bin/switch" start "${nodeConfig.closurePaths.system}")
 
@@ -352,6 +372,7 @@ in {
             set -e
             sleep 1
           done
+          ''}
 
           ${nodeConfig.postDeployScript}
 

--- a/scripts/switch
+++ b/scripts/switch
@@ -63,6 +63,17 @@ switch-start() {
   echo "$id"
 }
 
+switch-boot() {
+  local system=$1
+  if ! [ -x "$system/bin/switch-to-configuration" ]; then
+    echo "$system doesn't appear to be a NixOS system" >&2
+    exit 1
+  fi
+
+  nix-env -p /nix/var/nix/profiles/system --set "$system"
+  switch "$system" boot
+}
+
 switch-active() {
   local id=$1
   cat "system-$id/status"
@@ -165,6 +176,9 @@ switch-run() {
 case "$1" in
   "start")
     switch-start "$2"
+    ;;
+  "boot")
+    switch-boot "$2"
     ;;
   "active")
     switch-active "$2"


### PR DESCRIPTION
Sometimes it's needed to do a deployment, but only on the next reboot. Ie. there was a recent change in dbus, which prevented switching to the configuration.

This would allow setting `switchAction` to `boot`.